### PR TITLE
Increase default benchmark iterations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {basisTranscoding, encoding} from './benchmarks/basis';
 
 const DEFAULT_N_ITERATIONS = 1000;
 
-// This benchmark is long-running, it should not run for more than 5 iterations in CI.
+// These benchmarks take longer to run per iteration. Total benchmark time should be no longer than 1 minute.
 const MAX_BASIS_ENCODING_ITERATIONS = 5;
 const MAX_BASIS_TRANSCODING_ITERATIONS = 50;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,24 @@
-import React, { useMemo } from 'react';
+import React, {useMemo} from 'react';
+import {ScrollView, StyleSheet, Text, TextInput, View} from 'react-native';
 import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from 'react-native';
-import { BenchmarkHarness, BenchmarkDescriptor } from './react-native-benchmarking-library';
-import { advancedDracoBenchmark, simpleDracoBenchmark } from './benchmarks/draco';
-import { basisTranscoding, encoding } from './benchmarks/basis';
+  BenchmarkHarness,
+  BenchmarkDescriptor,
+} from './react-native-benchmarking-library';
+import {advancedDracoBenchmark, simpleDracoBenchmark} from './benchmarks/draco';
+import {basisTranscoding, encoding} from './benchmarks/basis';
 
+const DEFAULT_N_ITERATIONS = 1000;
+
+// This benchmark is long-running, it should not run for more than 5 iterations in CI.
+const MAX_BASIS_ENCODING_ITERATIONS = 5;
 
 function App(): React.JSX.Element {
-  const [numIterations, setNumIterations] = React.useState<string>(String(5));
+  const [numIterations, setNumIterations] = React.useState<string>(
+    String(DEFAULT_N_ITERATIONS),
+  );
   const BENCHMARK_MATRIX: BenchmarkDescriptor[] = useMemo(() => {
     const iterations = parseInt(numIterations, 10);
-    return ([
+    return [
       {
         title: 'Draco: Decoding',
         benchmarkType: 'headless',
@@ -29,31 +32,32 @@ function App(): React.JSX.Element {
       {
         title: 'Basis: File Encoding To KTX2',
         benchmarkType: 'headless',
-        benchmarkFn: encoding(iterations),
+        benchmarkFn: encoding(
+          Math.min(MAX_BASIS_ENCODING_ITERATIONS, iterations),
+        ),
       },
       {
         title: 'Basis: File Transcoding From .basis',
         benchmarkType: 'headless',
         benchmarkFn: basisTranscoding(iterations),
       },
-    ]);
+    ];
   }, [numIterations]);
 
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      style={styles.container}
-    >
+      style={styles.container}>
       <Text style={styles.title}>IR Engine Benchmark suite</Text>
-      <View style={{ flexDirection: 'row', alignItems: 'center'}}>
+      <View style={{flexDirection: 'row', alignItems: 'center'}}>
         <Text style={styles.text}>Number of iterations</Text>
-      <TextInput
-        style={styles.input}
-        onChangeText={setNumIterations}
-        value={numIterations}
-        placeholder="Number of iterations"
-        keyboardType="numeric"
-      />
+        <TextInput
+          style={styles.input}
+          onChangeText={setNumIterations}
+          value={numIterations}
+          placeholder="Number of iterations"
+          keyboardType="numeric"
+        />
       </View>
       <BenchmarkHarness items={BENCHMARK_MATRIX} />
     </ScrollView>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ const DEFAULT_N_ITERATIONS = 1000;
 
 // This benchmark is long-running, it should not run for more than 5 iterations in CI.
 const MAX_BASIS_ENCODING_ITERATIONS = 5;
+const MAX_BASIS_TRANSCODING_ITERATIONS = 50;
 
 function App(): React.JSX.Element {
   const [numIterations, setNumIterations] = React.useState<string>(
@@ -39,7 +40,9 @@ function App(): React.JSX.Element {
       {
         title: 'Basis: File Transcoding From .basis',
         benchmarkType: 'headless',
-        benchmarkFn: basisTranscoding(iterations),
+        benchmarkFn: basisTranscoding(
+          Math.min(MAX_BASIS_TRANSCODING_ITERATIONS, iterations),
+        ),
       },
     ];
   }, [numIterations]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ const DEFAULT_N_ITERATIONS = 1000;
 
 // These benchmarks take longer to run per iteration. Total benchmark time should be no longer than 1 minute.
 const MAX_BASIS_ENCODING_ITERATIONS = 5;
-const MAX_BASIS_TRANSCODING_ITERATIONS = 50;
+const MAX_BASIS_TRANSCODING_ITERATIONS = 100;
 
 function App(): React.JSX.Element {
   const [numIterations, setNumIterations] = React.useState<string>(


### PR DESCRIPTION
Increases the iteration count from 5 -> 1000 for all benchmarks, setting caps for the long-running basis benchmarks.